### PR TITLE
fix problem when trying to fetch secrets from the cluster

### DIFF
--- a/cluster/charts/ess-plugin-vault/templates/rbac.yaml
+++ b/cluster/charts/ess-plugin-vault/templates/rbac.yaml
@@ -8,6 +8,9 @@ rules:
   - apiGroups: ["secrets.crossplane.io"]
     resources: ["vaultconfigs"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +44,9 @@ func main() {
 	s := runtime.NewScheme()
 	err := v1alpha1.AddToScheme(s)
 	ctx.FatalIfErrorf(err, "cannot add apis to scheme")
+
+	err = corev1.AddToScheme(s)
+	ctx.FatalIfErrorf(err, "cannot add coreapis to scheme")
 
 	cfg, err := ctrl.GetConfig()
 	ctx.FatalIfErrorf(errors.Wrap(err, "cannot get config"))

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/vault/api v1.9.0
 	github.com/hashicorp/vault/api/auth/kubernetes v0.4.0
 	google.golang.org/grpc v1.51.0
+	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	sigs.k8s.io/controller-runtime v0.14.1
 	sigs.k8s.io/controller-tools v0.11.1
@@ -88,7 +89,6 @@ require (
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.26.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/client-go v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect


### PR DESCRIPTION
Hello everybody!

After trying to go forward with the potential integration of the `ess-plugin-vault` I stumbled across two bugs:

1. As in `main.go` a completely new `runtime.NewSchem()` is used the resulting kubernetes client does not know about any types at all. Currently only the `VaultConfig` types gets added. This causes a problem when trying to resolve `secretRef`s (either for `Token` or `Kubernetes` based authentication) from the `CommonCredentialsSelector` as the client now needs to get a kubernetes Secret. Therefore I added the core apis from kubernetes to the scheme so that the resulting client is able to interact properly
2. After that I got one step further and the `ServiceAccount` used by the `ess-plugin-vault` does not have permissions to interact with any resources besides the `VaultConfig` mentioned above. And again in order to resolve `secretRef`s the `ServiceAccount` needs to have permissions to at least get secrets from the cluster. I added that to the `ClusterRole` of the helm chart.

I hope it is fine that I directly created a PR rather than opening up an issue first.